### PR TITLE
DON'T MERGE: Custom test to override and fix old runTest.exact, re: #15

### DIFF
--- a/Data_Analysis/Central_Tendency/customTests.R
+++ b/Data_Analysis/Central_Tendency/customTests.R
@@ -1,0 +1,11 @@
+runTest <- function(...)UseMethod("runTest")
+
+runTest.exact <- function(keyphrase,e){
+  is.correct <- FALSE
+  if(is.numeric(e$val)){
+    correct.ans <- eval(parse(text=rightside(keyphrase)))
+    epsilon <- 0.01*abs(correct.ans)
+    is.correct <- abs(e$val-correct.ans) <= epsilon
+  }
+  return(isTRUE(is.correct))
+}


### PR DESCRIPTION
1. Fixed for Central Tendency lesson only.
2. To fix for others, copy customTests.R to other lessons. Easy but awaiting second opinion.
3. I don't see that this problem applies to questions other than those using runTest.exact.
