### PR TITLE
DON'T MERGE: Fix for expr creates var failure in R Programming

### DIFF
--- a/R_Programming/Matrices_and_Data_Frames/customTests.R
+++ b/R_Programming/Matrices_and_Data_Frames/customTests.R
@@ -39,3 +39,48 @@ calculates_same_value <- function(expr){
   if(!passed)e$delta <- list()
   return(passed)
 }
+
+omnitest <- function(correctExpr=NULL, correctVal=NULL, strict=FALSE){
+  e <- get("e", parent.frame())
+  # Trivial case
+  if(is.null(correctExpr) && is.null(correctVal))return(TRUE)
+  # Testing for correct expression only
+  if(!is.null(correctExpr) && is.null(correctVal)){
+    passed <- expr_identical_to(correctExpr)
+    if(!passed)e$delta <- list()
+    return(passed)
+  }
+  # Testing for both correct expression and correct value
+  # Value must be character or single number
+  valGood <- NULL
+  if(!is.null(correctVal)){
+    if(is.character(e$val)){
+      valResults <- expectThat(e$val,
+                               is_equivalent_to(correctVal, label=correctVal),
+                               label=(e$val))
+      if(is(e, "dev") && !valResults$passed)swirl_out(valResults$message)
+      valGood <- valResults$passed
+      # valGood <- val_matches(correctVal)
+    } else if(!is.na(e$val) && is.numeric(e$val) && length(e$val) == 1){
+      cval <- try(as.numeric(correctVal), silent=TRUE)
+      valResults <- expectThat(e$val, 
+                               equals(cval, label=correctVal),
+                               label=toString(e$val))
+      if(is(e, "dev") && !valResults$passed)swirl_out(valResults$message)
+      valGood <- valResults$passed
+    }
+  }
+  exprGood <- ifelse(is.null(correctExpr), TRUE, expr_identical_to(correctExpr))
+  if(valGood && exprGood){
+    return(TRUE)
+  } else if (valGood && !exprGood && !strict){
+    swirl_out("That's not the expression I expected but it works.")
+    swirl_out("I've executed the correct expression in case the result is needed in an upcoming question.")
+    eval(parse(text=correctExpr),globalenv())
+    return(TRUE)
+  } else {
+    e$delta <- list()
+    return(FALSE)
+  }
+}
+

--- a/R_Programming/Vectors/customTests.R
+++ b/R_Programming/Vectors/customTests.R
@@ -28,3 +28,47 @@ expr_creates_var <- function(correctName=NULL){
   }
   return(results$passed)
 }
+
+omnitest <- function(correctExpr=NULL, correctVal=NULL, strict=FALSE){
+  e <- get("e", parent.frame())
+  # Trivial case
+  if(is.null(correctExpr) && is.null(correctVal))return(TRUE)
+  # Testing for correct expression only
+  if(!is.null(correctExpr) && is.null(correctVal)){
+    passed <- expr_identical_to(correctExpr)
+    if(!passed)e$delta <- list()
+    return(passed)
+  }
+  # Testing for both correct expression and correct value
+  # Value must be character or single number
+  valGood <- NULL
+  if(!is.null(correctVal)){
+    if(is.character(e$val)){
+      valResults <- expectThat(e$val,
+                               is_equivalent_to(correctVal, label=correctVal),
+                               label=(e$val))
+      if(is(e, "dev") && !valResults$passed)swirl_out(valResults$message)
+      valGood <- valResults$passed
+      # valGood <- val_matches(correctVal)
+    } else if(!is.na(e$val) && is.numeric(e$val) && length(e$val) == 1){
+      cval <- try(as.numeric(correctVal), silent=TRUE)
+      valResults <- expectThat(e$val, 
+                               equals(cval, label=correctVal),
+                               label=toString(e$val))
+      if(is(e, "dev") && !valResults$passed)swirl_out(valResults$message)
+      valGood <- valResults$passed
+    }
+  }
+  exprGood <- ifelse(is.null(correctExpr), TRUE, expr_identical_to(correctExpr))
+  if(valGood && exprGood){
+    return(TRUE)
+  } else if (valGood && !exprGood && !strict){
+    swirl_out("That's not the expression I expected but it works.")
+    swirl_out("I've executed the correct expression in case the result is needed in an upcoming question.")
+    eval(parse(text=correctExpr),globalenv())
+    return(TRUE)
+  } else {
+    e$delta <- list()
+    return(FALSE)
+  }
+}


### PR DESCRIPTION
The original test, expr_creates_var, fails when AUTO_DETECT_NEWVAR is TRUE and the user creates extraneous variables, e.g. misspelling a name, in the course of answering a question. A custom test of the same name masks the original and ignores extraneous values. The custom test is included in Vectors and in Matrices and Data Frames.

The original test is also used in Regression Models, but since I believe AUTO_DETECT_NEWVAR is FALSE in all or most of its lessons, I've not altered them yet. I'm checking for problems
