### PR TITLE
Solves swirl issue #171 for Data Analysis, Central Tendency

### DIFF
--- a/Data_Analysis/Central_Tendency/customTests.R
+++ b/Data_Analysis/Central_Tendency/customTests.R
@@ -15,6 +15,5 @@ runTest.exact <- function(keyphrase,e){
 # of "=" in keyphrase
 # keyphrase:equivalent=expression
 runTest.equivalent <- function(keyphrase,e) {
-  print(omnitest(rightside(keyphrase)))
   return(omnitest(rightside(keyphrase)))
 }


### PR DESCRIPTION
On windows 8, the old answer test, runTest.equivalent can fail. A custom test of the same name which masks the old test and wraps omnitest(correctExpr) solves the problem.
