### PR TITLE
Correct the side of the larger operand

### DIFF
--- a/R_Programming/Logic/lesson.yaml
+++ b/R_Programming/Logic/lesson.yaml
@@ -139,7 +139,7 @@
 
 - Class: text
   Output: What happens in this case is that the left operand `TRUE` is recycled
-    across every element in the vector of the left operand. This is the equivalent
+    across every element in the vector of the right operand. This is the equivalent
     statement as c(TRUE, TRUE, TRUE) & c(TRUE, FALSE, FALSE). 
 
 - Class: cmd_question


### PR DESCRIPTION
In the **Logic** lesson of the **R Programming** course, there is an explanation of a vector being recycled because of the difference in length. I believe there is an error when specifying the side of the larger vector.
