### PR TITLE
normalizePath is the right command to return full path

### DIFF
--- a/R_Programming/Workspace_and_Files/lesson.yaml
+++ b/R_Programming/Workspace_and_Files/lesson.yaml
@@ -164,9 +164,9 @@
 
 - Class: cmd_question
   Output: Provide the full path to the file "mytest3.R".
-  CorrectAnswer: file.path("mytest3.R")
-  AnswerTests: omnitest(correctExpr='file.path("mytest3.R")')
-  Hint: file.path("mytest3.R") works.
+  CorrectAnswer: normalizePath("mytest3.R")
+  AnswerTests: omnitest(correctExpr='normalizePath("mytest3.R")')
+  Hint: normalizePath("mytest3.R") works.
 
 - Class: cmd_question
   Output: Create a directory in the current working directory called "testdir2" and a subdirectory for it called "testdir3", all in one command.


### PR DESCRIPTION
According to the definition of Unix paths[1][2], "full path" refers to the absolute path, unique location regardless of the present working directory.

```r
> file.path("mytest3.R")
[1] "mytest3.R"
> normalizePath("mytest3.R")
[1] "/Users/irio/Code/r_programming/assignment_1/testdir/mytest3.R"
```

---

[1]
<blockquote>
Systems can use either absolute or relative paths. A full path or
absolute path is a path that points to the same location on one file
system regardless of the present working directory or combined paths. As
such it must always contain the root directory.
</blockquote>
http://en.wikipedia.org/wiki/Path_%28computing%29

[2]
<blockquote>
A full pathname is just a path that starts at the root directory, i.e., begins with the slash (/) character.

Any example full path is:

    /usr/bin/man

which is the location of the man command.
</blockquote>
https://www.cs.bu.edu/teaching/unix/reference/vocab.html