### PR TITLE
Handle swirl exit on error from plot.new()

### DIFF
--- a/Statistical_Inference/Variance/plotVform.R
+++ b/Statistical_Inference/Variance/plotVform.R
@@ -1,6 +1,15 @@
 #fname <- paste(getwd(),"Statistical_Inference/Variance/Vform.jpeg",sep="/")
 fname <- pathtofile("Vform.jpeg")
 try(dev.off(),silent=TRUE)
-plot.new()
+tryCatch( {
+    plot.new()
+    },
+    error=function(e){
+        if(as.character(e)=="Error in plot.new(): figure margins too large\n"){
+            print("Plot window too small. Increase size of the plot window")
+            par(mar=rep(1,4))
+            plot.new()
+    }
+})
 plotArea=par('fig')
 rasterImage(readJPEG(fname),plotArea[1],plotArea[3],plotArea[2],plotArea[4],interpolate=FALSE)


### PR DESCRIPTION
plot.new() exits with error - "Error in plot.new(): figure margins too large" when plot window is too small in RStudio.
Handle swirl exit on error from plot.new() and ask user to resize window.

There are about ~120 course files which will need this change if accepted.

Let me know if this is ok and I will make the changes in the other files as well. 