### PR TITLE
Reset graphics driver before std. normal plot

### DIFF
--- a/Statistical_Inference/CommonDistros/plotNormal.R
+++ b/Statistical_Inference/CommonDistros/plotNormal.R
@@ -4,4 +4,5 @@ library(ggplot2)
 g <- ggplot(dat, 
               aes(x = x, y = y)) + geom_line(size = 1.5)
 g <- g + geom_vline(xintercept = -4 : 4, size = 1)
+try(dev.off(),silent=TRUE)
 print(g)


### PR DESCRIPTION
Reset graphics driver to avoid "invalid graphics state" Error

Sample Error run before change

| Here's a picture of the density function of a standard normal distribution. It's
| centered at its mean 0 and the vertical lines (at the integer points of the x-axis)
| indicate the standard deviations.

Error in .Call.graphics(C_palette2, .Call(C_palette2, NULL)) : 
  invalid graphics state

| Leaving swirl now. Type swirl() to resume.