### PR TITLE
Updated example for remainder() function to show a much better test case

### DIFF
--- a/R_Programming/Functions/lesson.yaml
+++ b/R_Programming/Functions/lesson.yaml
@@ -132,10 +132,10 @@
 
 - Class: cmd_question
   Output: "Now let's test the remainder function by providing two arguments.
-    Type: remainder(11, 5) and let's see what happens."
-  CorrectAnswer: remainder(11, 5)
-  AnswerTests: omnitest(correctExpr='remainder(11, 5)')
-  Hint: "Let's test your remainder function by running: remainder(11, 5)"
+    Type: remainder(5, 3) and let's see what happens."
+  CorrectAnswer: remainder(5, 3)
+  AnswerTests: omnitest(correctExpr='remainder(5, 3)')
+  Hint: "Let's test your remainder function by running: remainder(5, 3)"
 
 - Class: text
   Output: "Once again, the arguments have been matched appropriately."


### PR DESCRIPTION
The lesson shows that instead of using remainder() with the divisor argument set to it's default value (2), we can also use it by passing our own argument to the function. The example used here is remainder(11,5) and although there's nothing wrong with it I'd like to point out that it has the same result as calling remainder(11,2) and it's not the best way to test  if the divisor argument works or not. Let's say the student would make a mistake and set divisor <- 2 in the function call in a hypothetical programming task. He would fail to recognize that the function does not work well if he tests remainder(5), remainder(11, 5) and concludes that the function works well as he got the right result for both cases. In reality remainder(11,5) gives the same results as using using the default value and thus is not a good test.