### PR TITLE
Adds note on how to fix breaking error when displaying plots

### DIFF
--- a/Data_Analysis/Central_Tendency/lesson.yaml
+++ b/Data_Analysis/Central_Tendency/lesson.yaml
@@ -22,6 +22,7 @@
 
 - Class: figure
   Output: Here is a diagram showing the relationship between a population and a sample.
+    If you get an error, try increasing the size of yoru "Plots" window.
   Figure: mod1_pop_vs_samp.R
   FigureType: new
 


### PR DESCRIPTION
I ran into the same issue referenced in https://github.com/swirldev/swirl/issues/256, which was resolved using their solution of increasing the size of the "Plots" window. I simply added a single-line note about this to the preceding instruction so it would be easier for others to address. 

While I generally hate adding in extraneous parts to the user experience that are not universally applicable, this issue came up enough times that I think it is worth addressing, and the single extra line should not create much cognitive burden for people unaffected by this issue. 

Thanks for the great package!