### PR TITLE
Missing line return

### DIFF
--- a/Exploratory_Data_Analysis/Graphics_Devices_in_R/lesson
+++ b/Exploratory_Data_Analysis/Graphics_Devices_in_R/lesson
@@ -159,3 +159,4 @@
   AnswerChoices: Yes;No
   AnswerTests: coursera_on_demand()
   Hint: ""
+  


### PR DESCRIPTION
This file was missing a line return at the end that generated a warning when going through the lesson.  It didn't break the lesson, but it's pretty jarring.

```
| Run the R command ?Devices to see what graphics devices are available on your system.

warning messages from top-level task callback 'mini'
Warning message:
In readLines(input) :
  incomplete final line found on '/Library/Frameworks/R.framework/Versions/3.2/Resources/library/swirl/Courses/Exploratory_Data_Analysis/Graphics_Devices_in_R/lesson'
> 
```