### PR TITLE
Fixes #244 - Updated link to AQS State codes at 97% point in CaseStudy lesson

### DIFF
--- a/Exploratory_Data_Analysis/CaseStudy/lesson
+++ b/Exploratory_Data_Analysis/CaseStudy/lesson
@@ -504,7 +504,7 @@
   Hint: Type  mrg[mrg$mean.x < mrg$mean.y,] at the command prompt.
 
 - Class: text
-  Output: Only 4 states had worse pollution averages, and 2 of these had means that were very close. If you want to see which states (15, 31, 35, and 40) these are, you can check out this website http://www.epa.gov/envirofw/html/codes/state.html to decode the state codes.
+  Output: Only 4 states had worse pollution averages, and 2 of these had means that were very close. If you want to see which states (15, 31, 35, and 40) these are, you can check out this website https://aqs.epa.gov/aqsweb/codes/data/StateCountyCodes.html to decode the state codes.
 
 - Class: text
   Output: This concludes the lesson, comparing air pollution data from two years in different ways. First, we looked at measures of the entire set of monitors, then we compared the two measures from a particular monitor, and finally, we looked at the mean measures of the individual states. 


### PR DESCRIPTION
Old link was returning 404 as per issue. New link provides State & County codes with names.