### PR TITLE
Fix broken link

### DIFF
--- a/Exploratory_Data_Analysis/CaseStudy/lesson
+++ b/Exploratory_Data_Analysis/CaseStudy/lesson
@@ -504,7 +504,7 @@
   Hint: Type  mrg[mrg$mean.x < mrg$mean.y,] at the command prompt.
 
 - Class: text
-  Output: Only 4 states had worse pollution averages, and 2 of these had means that were very close. If you want to see which states (15, 31, 35, and 40) these are, you can check out this website http://www.epa.gov/envirofw/html/codes/state.html to decode the state codes.
+  Output: Only 4 states had worse pollution averages, and 2 of these had means that were very close. If you want to see which states (15, 31, 35, and 40) these are, you can check out this website https://www.epa.gov/enviro/state-fips-code-listing to decode the state codes.
 
 - Class: text
   Output: This concludes the lesson, comparing air pollution data from two years in different ways. First, we looked at measures of the entire set of monitors, then we compared the two measures from a particular monitor, and finally, we looked at the mean measures of the individual states. 


### PR DESCRIPTION
Found broken link when going through the lesson, found updated URL with the same information.

I didn't realize this got fixed until I went to submit this pull request.  The link in this commit is, in my opinion, more useful given the context.  

The link this is conflicting with is 4 pages of all state/county codes:  https://aqs.epa.gov/aqsweb/codes/data/StateCountyCodes.html  
The link I found is just the state codes:
https://www.epa.gov/enviro/state-fips-code-listing