### PR TITLE
Standard deviation referred to as variance - line 230

### DIFF
--- a/Statistical_Inference/T_Confidence_Intervals/lesson
+++ b/Statistical_Inference/T_Confidence_Intervals/lesson
@@ -227,7 +227,7 @@
   Output: The only term remaining is the standard error which for the single group is s/sqrt(n). Let's deal with the numerator first. Our interval will assume (for now) a common variance s^2 across the two groups. We'll actually pool variance information from the two groups using a weighted sum. (We'll deal with the more complicated situation later.) 
 
 - Class: text
-  Output: We call the variance estimator we use the pooled variance. The formula for it requires two variance estimators, S_x and S_y, one for each group. We multiply each by its respective degrees of freedom and divide the sum by the total number of degrees of freedom. This  weights the respective variances; those coming from bigger samples get more weight.
+  Output: We call the variance estimator we use the pooled variance. The formula for it requires two variance estimators (in the form of the standard deviation), S_x and S_y, one for each group. We multiply each by its respective degrees of freedom and divide the sum by the total number of degrees of freedom. This  weights the respective variances; those coming from bigger samples get more weight.
 
 - Class: mult_question
   Output: Which of the following represents the numerator of this expression?


### PR DESCRIPTION
In line 230, the independent variances are identified as S_x and S_y (which is unusual, because throughout the rest of the lesson, s stood for the standard deviation, not the variance).

Thus, the question and answers provided in the next few lines (233-237) are incorrect, because they show the correct answer including (S_x)^2 and so on, which would be the *variance* squared.

One fix is to label the variance estimators (S_x)^2 and (S_y)^2, another is to simply describe the variance estimators as "in the form of the standard deviation), as I've done here.