### PR TITLE
Hypothesis used in place of null hypothesis

### DIFF
--- a/Statistical_Inference/Power/lesson
+++ b/Statistical_Inference/Power/lesson
@@ -413,8 +413,8 @@
 - Class: mult_question
   Output: 2. What is a Type II error?
   AnswerChoices:   rejecting a true hypothesis;  rejecting a false hypothesis;  accepting a true hypothesis; accepting a false hypothesis
-  CorrectAnswer: accepting a false hypothesis
-  AnswerTests: omnitest(correctVal='accepting a false hypothesis')
+  CorrectAnswer: rejecting a true hypothesis
+  AnswerTests: omnitest(correctVal='rejecting a true hypothesis')
   Hint: Only two of the choices are errors. Eliminate those and then eliminate the Type I error.
 
 - Class: mult_question


### PR DESCRIPTION
Convention indicates you use "hypothesis" generally to refer to the alternative hypothesis, and null hypothesis specifically to refer to the, well, null hypothesis.

https://en.wikipedia.org/wiki/Type_I_and_type_II_errors