### PR TITLE
Statistical_Inference/Hypothesis_Testing: Plot standard normals

### DIFF
--- a/Statistical_Inference/Hypothesis_Testing/conf_5pct.R
+++ b/Statistical_Inference/Hypothesis_Testing/conf_5pct.R
@@ -1,7 +1,7 @@
 x <- seq(-8,8, length = 2000)
-dat <- data.frame(x=x, y=dnorm(x,sd=2))
-g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5)+scale_y_continuous(limits=c(0,max(dat$y)))
-suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(x>qnorm(.95,sd=2),x,NA)),
+dat <- data.frame(x=x, y=dnorm(x))
+g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5) + xlim(-4, 4) + scale_y_continuous(limits=c(0,max(dat$y)))
+suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(x>qnorm(.95),x,NA)),
             params=list(fill="red",alpha=.5, na.rm=TRUE)) )
 suppressWarnings(print(g))
 

--- a/Statistical_Inference/Hypothesis_Testing/conf_5pct_both.R
+++ b/Statistical_Inference/Hypothesis_Testing/conf_5pct_both.R
@@ -1,10 +1,10 @@
 x <- seq(-8,8, length = 2000)
-dat <- data.frame(x=x, y=dnorm(x,sd=2))
+dat <- data.frame(x=x, y=dnorm(x))
 library(ggplot2)
-g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5)+scale_y_continuous(limits=c(0,max(dat$y)))
-suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(x>qnorm(.975,sd=2),x,NA)),
+g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5) + xlim(-4, 4) + scale_y_continuous(limits=c(0,max(dat$y)))
+suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(x>qnorm(.975),x,NA)),
             params=list(fill="red",alpha=.5, na.rm=TRUE)) +
-   layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(-9<x & x<qnorm(.025,sd=2),x,NA)),
+   layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(-9<x & x<qnorm(.025),x,NA)),
                                                    params=list(fill="red",alpha=.5, na.rm=TRUE)) )
 suppressWarnings(print(g))
 

--- a/Statistical_Inference/Hypothesis_Testing/conf_5pct_left.R
+++ b/Statistical_Inference/Hypothesis_Testing/conf_5pct_left.R
@@ -1,6 +1,6 @@
 x <- seq(-8,8, length = 1000)
-dat <- data.frame(x=x, y=dnorm(x,sd=2))
-g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5) + scale_y_continuous(limits=c(0.0,max(dat$y)))
-suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(-9<x & x<qnorm(.05,sd=2),x,NA)),
+dat <- data.frame(x=x, y=dnorm(x))
+g <- ggplot(dat, aes(x = x, y = y)) + geom_line(size = 1.5) + xlim(-4, 4) + scale_y_continuous(limits=c(0.0,max(dat$y)))
+suppressWarnings(g <- g+ layer("area", stat="identity", position="identity",mapping = aes(x=ifelse(-9<x & x<qnorm(.05),x,NA)),
             params=list(fill="red",alpha=.5, na.rm=TRUE)) )
 suppressWarnings(print(g))

--- a/Statistical_Inference/Hypothesis_Testing/lesson
+++ b/Statistical_Inference/Hypothesis_Testing/lesson
@@ -95,7 +95,7 @@
   FigureType: new
 
 - Class: mult_question
-  Output: The shaded portion represents 5% of the area under this normal density curve. Which expression represents the smallest value X for which the area is shaded, assuming this is standard normal (which it really isn't)?
+  Output: The shaded portion represents 5% of the area under this normal density curve. Which expression represents the smallest value X for which the area is shaded, assuming this is standard normal?
   AnswerChoices: qnorm(.95); rnorm(.95); dnorm(.95); qt(.95,99)
   CorrectAnswer: qnorm(.95)
   AnswerTests: omnitest(correctVal='qnorm(.95)')


### PR DESCRIPTION
I found it slightly confusing that the text of the lesson and question answers were referring to standard normals, but the plots that were displayed were using sd = 2.

This changes the plotting code to plot standard normals. It also adds xlim(-4,4) so that the shape of the curve looks roughly the same as before. Compare these screenshots:

Before:
![before screenshot, sd = 2](https://cloud.githubusercontent.com/assets/277166/16270845/c05aebd2-3865-11e6-8ac9-28b64a1ca6d1.png)

After:
![after screenshot, sd = 1 with xlims](https://cloud.githubusercontent.com/assets/277166/16270846/c070b0ac-3865-11e6-85a2-0118a0957ef1.png)

