### PR TITLE
changed names for output of 'makelms' function in Regression_Models, …

### DIFF
--- a/Regression_Models/MultiVar_Examples/swissLMs.R
+++ b/Regression_Models/MultiVar_Examples/swissLMs.R
@@ -5,6 +5,7 @@ makelms <- function(){
           coef(lm(Fertility ~ Agriculture + Catholic + Education,swiss))[2],
           coef(lm(Fertility ~ Agriculture + Catholic + Education + Examination,swiss))[2],
           coef(lm(Fertility ~ Agriculture + Catholic + Education + Examination +Infant.Mortality, swiss))[2])
+	  names(cf) <- c("Agriculture", "Added 'Catholic'", "Added 'Education'", "Added 'Examination'", "Added 'Infant.Mortality'")
   print(cf)
 }
 


### PR DESCRIPTION
…MultiVar_Examples

Currently in Regression_Models/MultiVar_Examples, the output before one question is a little confusing. 

```

| Now run the function makelms() to see how the addition of variables affects the coefficient of Agriculture in the
| models.

> makelms()
Agriculture Agriculture Agriculture Agriculture Agriculture 
  0.1942017   0.1095281  -0.2030377  -0.2206455  -0.1721140 
...
| The addition of which variable changes the sign of Agriculture's coefficient from positive to negative?
```

Because every item in the output of `makelms()` is named `Agriculture`, I had to re-read the source code to answer this question. 

I changed the output to this:
```
makelms()
             Agriculture         Added 'Catholic'        Added 'Education'      Added 'Examination' 
               0.1942017                0.1095281               -0.2030377               -0.2206455 
Added 'Infant.Mortality' 
              -0.1721140 
```

This should make the question "The addition of **which variable** changes the sign of Agriculture's coefficient from positive to negative?" a little bit easier to answer. 