### PR TITLE
extract_numeric is deprecated, need readr

### DIFF
--- a/Getting_and_Cleaning_Data/Tidying_Data_with_tidyr/dependson.txt
+++ b/Getting_and_Cleaning_Data/Tidying_Data_with_tidyr/dependson.txt
@@ -1,2 +1,3 @@
+readr
 tidyr
 dplyr

--- a/Getting_and_Cleaning_Data/Tidying_Data_with_tidyr/lesson.yaml
+++ b/Getting_and_Cleaning_Data/Tidying_Data_with_tidyr/lesson.yaml
@@ -4,7 +4,7 @@
   Author: Nick Carchedi
   Type: Standard
   Organization: JHU Biostat
-  Version: 2.2.14
+  Version: 2.2.15
 
 - Class: text
   Output: In this lesson, you'll learn how to tidy your data with the tidyr package.
@@ -143,10 +143,16 @@
   Script: script3.R
 
 - Class: cmd_question
-  Output: Lastly, we want the values in the class column to simply be 1, 2, ..., 5 and not class1, class2, ..., class5. We can use the extract_numeric() function from tidyr to accomplish this. To see how it works, try extract_numeric("class5").
-  CorrectAnswer: extract_numeric("class5")
-  AnswerTests: omnitest('extract_numeric("class5")')
-  Hint: Type extract_numeric("class5") to see how it works.
+  Output: readr is required for certain data manipulations, such as `parse_numeric(), which will be used in the next question.  Let's, (re)load the package with library(readr).
+  CorrectAnswer: library(readr)
+  AnswerTests: omnitest('library(readr)')
+  Hint: Type library(readr) to (re)load the readr package.
+
+- Class: cmd_question
+  Output: Lastly, we want the values in the class column to simply be 1, 2, ..., 5 and not class1, class2, ..., class5. We can use the parse_numeric() function from readr to accomplish this. To see how it works, try parse_numeric("class5").
+  CorrectAnswer: parse_numeric("class5")
+  AnswerTests: omnitest('parse_numeric("class5")')
+  Hint: Type parse_numeric("class5") to see how it works.
 
 - Class: script
   Output: Now, the final step. Edit the R script, then save it and type submit() when you are ready. Type reset() to reset the script to its original state.


### PR DESCRIPTION
`extract_numeric` is deprecated in `tidyr`, and it says to use `readr::parse_numeric()`, so I changed that in text.