### PR TITLE
Corrected prompt which gave incorrect value

### DIFF
--- a/Exploratory_Data_Analysis/Exploratory_Graphs/lesson
+++ b/Exploratory_Data_Analysis/Exploratory_Graphs/lesson
@@ -360,7 +360,7 @@
   Figure: goodPlot3.R
 
 - Class: cmd_question
-  Output:  As before, use the up arrow key and change the 3 "west" strings to "east". 
+  Output:  As before, use the up arrow key and change the 3 "West" strings to "East". 
   CorrectAnswer: plot(east$latitude, east$pm25, main = "East")
   AnswerTests: omnitest(correctExpr='plot(east$latitude, east$pm25, main = "East")')
   Hint: Type  plot(east$latitude, east$pm25, main = "East") at the command prompt.


### PR DESCRIPTION
In line 363, **_Output_** said to change "**west**" to "**east**". The CorrectAnswer, however, requires it to be "**East**", in proper case. **_Output_** was modified to correctly show "**_East_**" and "**_West_**" proper case .