### PR TITLE
Correct 2 wrong answers in 3rd question of 1st lesson of EDA

### DIFF
--- a/Exploratory_Data_Analysis/Principles_of_Analytic_Graphs/lesson
+++ b/Exploratory_Data_Analysis/Principles_of_Analytic_Graphs/lesson
@@ -53,7 +53,7 @@
 
 - Class: mult_question
   Output: What does this graph NOT show you?
-  AnswerChoices:  Children in the control group had at most 3 symptom-free days; 75% of the children using the air cleaner had at most 3 symptom-free days; Half the chidren in the control group had no improvement; Using the air cleaner makes asthmatic children sicker
+  AnswerChoices:  Children in the control group had at most an increase of 3 symptom-free days; 75% of the children using the air cleaner had at most an increase of 3 symptom-free days; Half the chidren in the control group had no improvement; Using the air cleaner makes asthmatic children sicker
   CorrectAnswer: Using the air cleaner makes asthmatic children sicker
   AnswerTests: omnitest(correctVal='Using the air cleaner makes asthmatic children sicker')
   Hint: Since the boxplot on the right shows that the number of symptom-free days increases with air cleaner use, the graph does NOT show that use makes the children sicker.


### PR DESCRIPTION
The first 2 answers to the 3rd question of lesson
Principles_of_Analytic_Graphs of Exploratory_Data_Analysis were
incorrect.
They acted as if Figure AirCln2.jpeg shows Symptom-free days,
while in fact it shows the Change in symptom-free days.

Therefore, I changed "at most 3 symptom-free days" into
"at most an increase of 3 symptom-free days" in both answers.