### PR TITLE
typo "simply things" -> "simplify things"

### DIFF
--- a/R_Programming/Subsetting_Vectors/lesson.yaml
+++ b/R_Programming/Subsetting_Vectors/lesson.yaml
@@ -132,7 +132,7 @@
   Output: A shorthand way of specifying multiple negative numbers is to put the negative sign out in front of the vector of positive numbers. Type x[-c(2, 10)] to get the exact same result.
   CorrectAnswer: x[-c(2, 10)]
   AnswerTests: omnitest(correctExpr='x[-c(2, 10)]')
-  Hint: Use x[-c(2, 10)] to simply things a bit. This could be a time saver if specifying many negative indexes.
+  Hint: Use x[-c(2, 10)] to simplify things a bit. This could be a time saver if specifying many negative indexes.
 
 - Class: text
   Output: So far, we've covered three types of index vectors -- logical, positive integer, and negative integer. The only remaining type requires us to introduce the concept of 'named' elements.


### PR DESCRIPTION
as described in the title