### PR TITLE
also load tibble package

### DIFF
--- a/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/dependson.txt
+++ b/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/dependson.txt
@@ -1,1 +1,2 @@
 dplyr
+tibble


### PR DESCRIPTION
Also load tibble package to use as_tibble() function instead of deprecated dplyr::tbl_df() function.