### PR TITLE
changing the hint at 19%

### DIFF
--- a/Statistical_Inference/ConditionalProbability/lesson
+++ b/Statistical_Inference/ConditionalProbability/lesson
@@ -47,7 +47,7 @@
   AnswerChoices: (1/6)/(1/2); (1/2)/(1/6); (1/3)/(1/2); 1/6 
   CorrectAnswer: (1/6)/(1/2)
   AnswerTests: omnitest(correctVal='(1/6)/(1/2)')
-  Hint: Here A is a subset of B so the probability of both A AND B happening is the probability of A happening. The probability of B is the reciprocal of the number of odd numbers between 1 and 6 (inclusive).
+  Hint: Here A is a subset of B so the probability of both A AND B happening is the probability of A happening. The probability of B is the probability of an odd number occurring.
 
 - Class: text
   Output: From the definition of P(A|B), we can write P(A&B) = P(A|B) * P(B), right?  Let's use this to express P(B|A).


### PR DESCRIPTION
The number of odd numbers between 1 and 6 is 3. The reciprocal of 3 is 1/3, but the answer is 1/2. I would like to suggest the wording should be either "The probability of B is the reciprocal of the fraction of odd numbers to the number of sides of a die" or "The probability of B is the probability of an odd number occurring".