### PR TITLE
Fix yaml scanner error

### DIFF
--- a/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/lesson.yaml
+++ b/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/lesson.yaml
@@ -202,7 +202,7 @@
   Output: 'Now, put an exclamation point (!) before is.na() to change all of the TRUEs to FALSEs and all of the FALSEs to TRUEs, thus telling us what is NOT NA: !is.na(c(3, 5, NA, 10)).'
   CorrectAnswer: "!is.na(c(3, 5, NA, 10))"
   AnswerTests: omnitest('!is.na(c(3, 5, NA, 10))')
-  Hint: !is.na(c(3, 5, NA, 10)) will negate the previous command, thus telling us what is NOT NA.
+  Hint: '!is.na(c(3, 5, NA, 10)) will negate the previous command, thus telling us what is NOT NA.'
 
 - Class: cmd_question
   Output: 'Okay, ready to put all of this together? Use filter() to return all rows of cran for which r_version is NOT NA. Hint: You will need to use !is.na() as part of your second argument to filter().'


### PR DESCRIPTION
This fixes an error that prevents me from loading the "Manipulating Data with dplyr" lesson in the "Getting and Cleaning Data" course.

I'm not the only one suffering from this; it also closes #504 #502 #498

Previously I saw this error:

Error in yaml.load(readLines(con, warn = readLines.warn), error.label = error.label,  :
  (/home/gdb/R/x86_64-pc-linux-gnu-library/4.2/swirl/Courses/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/lesson.yaml) Scanner error: while scanning a tag at line 205, column 9 did not find expected whitespace or line break at line 205, column 19

It looks as though beginning a string with a '!' became problematic. Fixed by adding single quotes.