### PR TITLE
Use as_tibble() instead of tbl_df() which was deprecated in dplyr 1.0.0.

### DIFF
--- a/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/initLesson.R
+++ b/Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/initLesson.R
@@ -23,6 +23,6 @@ path2csv <- file.path(.get_course_path(),
 # doing this, but it will be necessary for students who
 # quit and later resume. We are not saving the variable
 # to the progress file to save on performance.
-cran <- tbl_df(read.csv(path2csv, stringsAsFactors = FALSE))
+cran <- as_tibble(read.csv(path2csv, stringsAsFactors = FALSE))
 cran2 <- select(cran, size:ip_id)
 cran3 <- select(cran, ip_id, package, size)


### PR DESCRIPTION
Swirl gives me a warning when starting Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr that tbl_df() has been deprecated, see capture below: 

```
warning messages from top-level task callback 'mini'
Warning message:
`tbl_df()` was deprecated in dplyr 1.0.0.
ℹ Please use `tibble::as_tibble()` instead.
ℹ The deprecated feature was likely used in the swirl package.
  Please report the issue to the authors.
This warning is displayed once every 8 hours.
Call `lifecycle::last_lifecycle_warnings()` to see where this warning was generated. 
> lifecycle::last_lifecycle_warnings()
[[1]]
<warning/lifecycle_warning_deprecated>
Warning:
`tbl_df()` was deprecated in dplyr 1.0.0.
ℹ Please use `tibble::as_tibble()` instead.
ℹ The deprecated feature was likely used in the swirl package.
  Please report the issue to the authors.
---
Backtrace:
     ▆
  1. └─swirl (local) cb(expr, value, succeeded, visible)
  2.   ├─swirl:::resume(e, ...)
  3.   └─swirl:::resume.default(e, ...)
  4.     ├─swirl:::mainMenu(e)
  5.     └─swirl:::mainMenu.default(e)
  6.       ├─swirl:::restoreUserProgress(e, response)
  7.       └─swirl:::restoreUserProgress.default(e, response)
  8.         └─(function() {...
  9.           ├─base::source(initf, local = TRUE)
 10.           │ ├─base::withVisible(eval(ei, envir))
 11.           │ └─base::eval(ei, envir)
 12.           │   └─base::eval(ei, envir)
 13.           └─dplyr::tbl_df(read.csv(path2csv, stringsAsFactors = FALSE)) at Getting_and_Cleaning_Data/Manipulating_Data_with_dplyr/initLesson.R:26:0
```
