### PR TITLE
Update to logic lesson to prevent unpassable error

### DIFF
--- a/R_Programming/Logic/lesson.yaml
+++ b/R_Programming/Logic/lesson.yaml
@@ -131,7 +131,7 @@
 
 - Class: cmd_question
   Output: "You can use the `&` operator to evaluate AND across a vector. The `&&` version of AND only evaluates 
-    the first member of a vector. Let's test both for practice. Type the expression TRUE & c(TRUE, FALSE, FALSE)."
+    logical vectors of length-one. Let's test both for practice. Type the expression TRUE & c(TRUE, FALSE, FALSE)."
   CorrectAnswer: "TRUE & c(TRUE, FALSE, FALSE)"
   AnswerTests: omnitest(correctExpr='TRUE & c(TRUE, FALSE, FALSE)')
   Hint: "Now to see how the AND operator works with a vector, type: 
@@ -143,16 +143,16 @@
     statement as c(TRUE, TRUE, TRUE) & c(TRUE, FALSE, FALSE). 
 
 - Class: cmd_question
-  Output: "Now we'll type the same expression except we'll use the `&&` operator. Type the expression TRUE && TRUE."
+  Output: "Now we'll try the `&&` operator. Type the expression TRUE && TRUE."
   CorrectAnswer: "TRUE && TRUE"
   AnswerTests: omnitest(correctExpr='TRUE && TRUE')
   Hint: "As you'll see, the && version of AND works differently. Type: 
     TRUE && TRUE"
 
 - Class: text
-  Output: "In this case, the left operand is only evaluated against a length-one logical vector
-  on the right. Since R 4.3.0, if provided vectors of length greater than one, this is always an error. In earlier
-  R versions the first elements of the LHS and RHS would be evaluated against each other"
+  Output: "In this case, the left and right operands are length-one logical vectors.
+  Since R 4.3.0, if provided vectors of length greater than one, `&&` produces an error. In earlier
+  R versions the first elements of the LHS and RHS would be evaluated against each other."
     
 - Class : text
   Output: The OR operator follows a similar set of rules. The `|` version of OR

--- a/R_Programming/Logic/lesson.yaml
+++ b/R_Programming/Logic/lesson.yaml
@@ -151,8 +151,8 @@
 
 - Class: text
   Output: "In this case, the left and right operands are length-one logical vectors.
-  Since R 4.3.0, if provided vectors of length greater than one, `&&` produces an error. In earlier
-  R versions the first elements of the LHS and RHS would be evaluated against each other."
+    Since R 4.3.0, if provided vectors of length greater than one, `&&` produces an error. In earlier
+    R versions the first elements of the LHS and RHS would be evaluated against each other."
     
 - Class : text
   Output: The OR operator follows a similar set of rules. The `|` version of OR

--- a/R_Programming/Logic/lesson.yaml
+++ b/R_Programming/Logic/lesson.yaml
@@ -143,21 +143,21 @@
     statement as c(TRUE, TRUE, TRUE) & c(TRUE, FALSE, FALSE). 
 
 - Class: cmd_question
-  Output: "Now we'll type the same expression except we'll use the `&&` operator. Type the expression TRUE && c(TRUE, FALSE, FALSE)."
-  CorrectAnswer: "TRUE && c(TRUE, FALSE, FALSE)"
-  AnswerTests: omnitest(correctExpr='TRUE && c(TRUE, FALSE, FALSE)')
+  Output: "Now we'll type the same expression except we'll use the `&&` operator. Type the expression TRUE && TRUE."
+  CorrectAnswer: "TRUE && TRUE"
+  AnswerTests: omnitest(correctExpr='TRUE && TRUE')
   Hint: "As you'll see, the && version of AND works differently. Type: 
-    TRUE && c(TRUE, FALSE, FALSE)"
+    TRUE && TRUE"
 
 - Class: text
-  Output: "In this case, the left operand is only evaluated with the first member
-    of the right operand (the vector). The rest of the elements in the vector
-    aren't evaluated at all in this expression."
+  Output: "In this case, the left operand is only evaluated against a length-one logical vector
+  on the right. Since R 4.3.0, if provided vectors of length greater than one, this is always an error. In earlier
+  R versions the first elements of the LHS and RHS would be evaluated against each other"
     
 - Class : text
   Output: The OR operator follows a similar set of rules. The `|` version of OR
-    evaluates OR across an entire vector, while the `||` version of OR only evaluates
-    the first member of a vector.
+    evaluates OR across an entire vector, while the `||` version of OR only accepts
+    length-one logical vectors.
     
 - Class : text
   Output: An expression using the OR operator will evaluate to TRUE if the left 
@@ -174,11 +174,11 @@
   
 - Class: cmd_question
   Output: "Now let's try out the non-vectorized version of the OR operator. Type the 
-    expression TRUE || c(TRUE, FALSE, FALSE)."
-  CorrectAnswer: "TRUE || c(TRUE, FALSE, FALSE)"
-  AnswerTests: omnitest(correctExpr='TRUE || c(TRUE, FALSE, FALSE)')
+    expression TRUE || TRUE"
+  CorrectAnswer: "TRUE || TRUE"
+  AnswerTests: omnitest(correctExpr='TRUE || TRUE')
   Hint: "As you'll see the || version of OR is not vectorized. Type: 
-    TRUE || c(TRUE, FALSE, FALSE)"
+    TRUE || TRUE"
   
 - Class : text
   Output: "Logical operators can be chained together just like arithmetic operators.


### PR DESCRIPTION
R 4.3.0 introduced breaking change to '&&' operator allowing on length-one logical vector. Currently learners using R >= 4.3.0 get and error on the '&&' questions and cannot skip.
